### PR TITLE
Permit specification of alternate CSS template

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -273,7 +273,7 @@ module.exports = (options = {}) => {
                 return null;
             }
             return {
-                code: `${source}${config.generateCSS(getCSSFromCache(config.cache))}`,
+                code: `${source}${config.generateCode(getCSSFromCache(config.cache))}`,
                 map: null,
             };
         },

--- a/lib/index.js
+++ b/lib/index.js
@@ -227,6 +227,7 @@ module.exports = (options = {}) => {
         onParse: options.onParse,
         dest: options.dest,
         typescript: options.typescript,
+        generateCSS: options.generateCSS || genereateCSSScript,
     };
     if (config.typescript) {
         typescript = require('typescript');
@@ -272,7 +273,7 @@ module.exports = (options = {}) => {
                 return null;
             }
             return {
-                code: `${source}${genereateCSSScript(getCSSFromCache(config.cache))}`,
+                code: `${source}${config.generateCSS(getCSSFromCache(config.cache))}`,
                 map: null,
             };
         },

--- a/lib/index.js
+++ b/lib/index.js
@@ -227,7 +227,7 @@ module.exports = (options = {}) => {
         onParse: options.onParse,
         dest: options.dest,
         typescript: options.typescript,
-        generateCSS: options.generateCSS || genereateCSSScript,
+        generateCode: options.generateCode || genereateCSSScript,
     };
     if (config.typescript) {
         typescript = require('typescript');


### PR DESCRIPTION
Right now, I've got an old project with a simulated browser testing environment that does not include URL or Blob. Previously, I was building one of my components using `rollup-plugin-embed-css`, but had to move to a different solution since it was crashing the build.

This patch permits consumers to provide their own `generateCSS` option, for special cases such as this one.